### PR TITLE
Adding initial support for ULX5M-GS

### DIFF
--- a/072-dvi-lvds/ulx5m-gs.ccf
+++ b/072-dvi-lvds/ulx5m-gs.ccf
@@ -1,0 +1,37 @@
+#CLK
+Net  "clk_i"  Loc = "IO_SB_A8" | SCHMITT_TRIGGER=true;
+
+## BTN
+#Net "btn[0]" Loc = "IO_EA_B4" | PULLDOWN=true; 
+#Net "btn[1]" Loc = "IO_EA_A4" | PULLDOWN=true;
+#Net "btn[2]" Loc = "IO_EA_B3" | PULLDOWN=true; 
+
+#LED
+Net "led[0]" Loc = "IO_SB_A0";
+Net "led[1]" Loc = "IO_SB_B0";
+Net "led[2]" Loc = "IO_SB_A1";
+Net "led[3]" Loc = "IO_SB_B1";
+Net "led[4]" Loc = "IO_SB_B2";
+Net "led[5]" Loc = "IO_SB_A2";
+Net "led[6]" Loc = "IO_SB_B3";
+Net "led[7]" Loc = "IO_SB_A3";
+
+Net "TMDS_0_data_p[2]" Loc = "IO_SB_A6" | LVDS_BOOST=true;
+Net "TMDS_0_data_n[2]" Loc = "IO_SB_B6" | LVDS_BOOST=true;
+Net "TMDS_0_data_p[1]" Loc = "IO_SB_A5" | LVDS_BOOST=true;
+Net "TMDS_0_data_n[1]" Loc = "IO_SB_B5" | LVDS_BOOST=true;
+Net "TMDS_0_data_p[0]" Loc = "IO_SB_A4" | LVDS_BOOST=true;
+Net "TMDS_0_data_n[0]" Loc = "IO_SB_B4" | LVDS_BOOST=true;
+Net "TMDS_0_clk_p"     Loc = "IO_SB_A7" | LVDS_BOOST=true; 
+Net "TMDS_0_clk_n"     Loc = "IO_SB_B7" | LVDS_BOOST=true;
+
+# USB EA
+#Net "usb_fpga_dp"	Loc = "IO_EA_A0";
+#Net "usb_fpga_dn"	Loc = "IO_EA_B0";
+#Net "usb_fpga_bd_dp"	Loc = "IO_EA_A1";
+#Net "usb_fpga_bd_dn"	Loc = "IO_EA_B1";
+#Net "usb_fpga_pu_dp"	Loc = "IO_EA_A2";
+#Net "usb_fpga_pu_dn"	Loc = "IO_EA_B2";
+
+
+

--- a/makefile.inc
+++ b/makefile.inc
@@ -25,13 +25,16 @@ $(error BOARD variable is not set)
 endif
 
 ifeq ($(BOARD), olimex)
-OFL_BOARD=-b olimex_gatemateevb
+OFL_BOARD=-b olimex_gatemateevb -r
 FREQ = 10
+else ifeq ($(BOARD), ulx5m-gs)
+OFL_BOARD=-b olimex_gatemateevb -r -f
+FREQ = 25
 else ifeq ($(BOARD), kolsch)
-OFL_BOARD=-c dirtyJtag
+OFL_BOARD=-c dirtyJtag -r
 FREQ = 48
 else
-OFL_BOARD=-b gatemate_evb_jtag
+OFL_BOARD=-b gatemate_evb_jtag -f
 FREQ = 10
 endif
 

--- a/ulx5m-gs.vh
+++ b/ulx5m-gs.vh
@@ -1,0 +1,2 @@
+`define BOARD_FREQ_STR "25.0"
+`define BOARD_FREQ 25000000


### PR DESCRIPTION
Hi, 
I have created files needed for ULX5M-GS board.
I added ccf in only one folder for testing purposes.

That example 072-dvi-lvds is not building with pr  (trowing error) and with nextpnr on Olimex i sometimes get noisy picture but on short so something with timings is not right. 

Best, 
Goran