### PR TITLE
Fixed very minor syntax error in cpesim.v

### DIFF
--- a/cpesim.v
+++ b/cpesim.v
@@ -164,7 +164,7 @@ module CPE_LVDS_IOBUF (
 	input T,
 	output Y,
 	inout IO_P,
-	inout IO_N,
+	inout IO_N
 );
   assign IO_P = T ? 1'bz: A;
   assign IO_N = T ? 1'bz: ~A;


### PR DESCRIPTION
I just fixed a very minor syntax error in cpesim.v that xsim was unhappy about (extra comma at end of module definition).